### PR TITLE
Replace registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM quay.io/operator-framework/opm:latest
+FROM registry.redhat.io/openshift4/ose-operator-registry
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
This it the allowed registry.redhat.io/openshift4/ose-operator-registry for opm command

FBC-validation task will require to have this base image in FBC image, https://github.com/redhat-appstudio/build-definitions/pull/487